### PR TITLE
GH-3 Allow users to configure years to include in search

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -379,8 +379,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f00b5dbd620d61dfdcb6007c9c1f6054ebd75319f163d886a9055cec1155073d"
 dependencies = [
  "jiff-static",
+ "log",
  "portable-atomic",
  "portable-atomic-util",
+ "serde_core",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ repository = "https://github.com/OrangeTux/retrodate"
 [dependencies]
 argh = { version = "0.1.19", default-features = false, features = ["help"] }
 color-eyre = { version = "0.6.5", default-features = false }
-jiff = { version = "0.2.23", default-features = false }
+jiff = { version = "0.2.23", default-features = false, features = ["std"] }
 regex = { version = "1.12.3", default-features = false, features = ["unicode-perl"] }
 serde = { version = "1.0.228", default-features = false, features = ["derive"] }
 ureq = { version = "3.3.0", default-features = false, features = ["json", "rustls"] }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,16 +1,25 @@
 use color_eyre::eyre::{Report, Result};
-use jiff::civil::{Date, DateTime};
+use jiff::{
+    Zoned,
+    civil::{Date, DateTime},
+};
 use regex::Regex;
 use serde::{Deserialize, Serialize};
 use std::{
     collections::HashMap,
+    ops::RangeInclusive,
     sync::atomic::{AtomicBool, Ordering},
 };
 use ureq::http::Uri;
 
 pub static VERBOSE: AtomicBool = AtomicBool::new(false);
 
-/// Find assets on Immich which have a date in their file name.
+/// Retrodate is an utility to retroactively date images on Immich based on an image' filename.
+///
+/// This tool queries Immich for all filenames that contain a year, e.g. 2021 in 20210901_115950.jpg.
+/// Then, the date (and optional time) is parsed from the filename.
+///
+/// You can control search using the arguments --from-year and --until-year.
 #[derive(argh::FromArgs)]
 pub struct Args {
     /// API key providing access to Immich's API. It requires permissions 'asset.read' and 'asset.update'.
@@ -28,18 +37,29 @@ pub struct Args {
     /// explain what is being done
     #[argh(switch, short = 'v')]
     pub verbose: bool,
+
+    /// the earliest year to include in the search, defaults to 2000
+    #[argh(option, default = "2000")]
+    pub from_year: u16,
+
+    /// the latest year to include in the search, defaults to the current year
+    #[argh(option, default = "Zoned::now().year()")]
+    pub until_year: i16,
 }
 
 pub struct App {
     client: Client,
     apply: bool,
+
+    year_range: RangeInclusive<u16>,
 }
 
 impl App {
-    pub fn new(client: Client) -> Self {
+    pub fn new(client: Client, from_year: u16, until_year: u16) -> Self {
         Self {
             client,
             apply: false,
+            year_range: from_year..=until_year,
         }
     }
 
@@ -50,7 +70,7 @@ impl App {
 
     pub fn run(self) -> Result<()> {
         let re = Regex::new(r"(\d{8})(?:[_-](\d{6}))?").unwrap();
-        for year in 2000..2027 {
+        for year in self.year_range {
             let assets = get_assets_by_filename(&format!("{year}"), &self.client)?;
             debug(format!(
                 "Found {} assets that have {} in their file name.",
@@ -81,9 +101,9 @@ impl App {
                 {
                     let original_date_time = original_date_time.parse::<DateTime>().ok();
                     if let Some(original_date_time) = &original_date_time {
-                        if (*original_date_time - datetime).get_days() <= 1 {
-                            continue;
-                        };
+                        // if (*original_date_time - datetime).get_days() <= 1 {
+                        //     continue;
+                        // };
                         debug(format!(
                             "Date of {} will be updated from {:?} to {:?}",
                             asset.original_file_name, original_date_time, datetime,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,7 +14,7 @@ use ureq::http::Uri;
 
 pub static VERBOSE: AtomicBool = AtomicBool::new(false);
 
-/// Retrodate is an utility to retroactively date images on Immich based on an image' filename.
+/// Retrodate is a utility to retroactively date images on Immich based on an image's filename.
 ///
 /// This tool queries Immich for all filenames that contain a year, e.g. 2021 in 20210901_115950.jpg.
 /// Then, the date (and optional time) is parsed from the filename.
@@ -43,8 +43,8 @@ pub struct Args {
     pub from_year: u16,
 
     /// the latest year to include in the search, defaults to the current year
-    #[argh(option, default = "Zoned::now().year()")]
-    pub until_year: i16,
+    #[argh(option, default = "current_year()")]
+    pub until_year: u16,
 }
 
 pub struct App {
@@ -101,9 +101,9 @@ impl App {
                 {
                     let original_date_time = original_date_time.parse::<DateTime>().ok();
                     if let Some(original_date_time) = &original_date_time {
-                        // if (*original_date_time - datetime).get_days() <= 1 {
-                        //     continue;
-                        // };
+                        if (*original_date_time - datetime).get_days() <= 1 {
+                            continue;
+                        };
                         debug(format!(
                             "Date of {} will be updated from {:?} to {:?}",
                             asset.original_file_name, original_date_time, datetime,
@@ -265,6 +265,12 @@ pub struct Query {
 pub struct Patch {
     pub date_time_original: String,
 }
+
+// Return the current year.
+fn current_year() -> u16 {
+    Zoned::now().year().try_into().unwrap_or(2030)
+}
+
 #[cfg(test)]
 mod test {
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -13,7 +13,7 @@ fn main() -> Result<()> {
         })?,
         api_key: args.api_key,
     };
-    let mut app = App::new(client);
+    let mut app = App::new(client, args.from_year, args.until_year as u16);
     if args.apply {
         app = app.apply_changes();
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,7 +4,7 @@ use std::sync::atomic::Ordering;
 
 fn main() -> Result<()> {
     color_eyre::install()?;
-    let args: Args = argh::from_env();
+    let mut args: Args = argh::from_env();
     VERBOSE.store(args.verbose, Ordering::Relaxed);
 
     let client = Client {
@@ -13,6 +13,12 @@ fn main() -> Result<()> {
         })?,
         api_key: args.api_key,
     };
+
+    // Be forgiving if a user swapped the values from --from-year and --until-year.
+    if args.from_year > args.until_year {
+        std::mem::swap(&mut args.from_year, &mut args.until_year);
+    }
+
     let mut app = App::new(client, args.from_year, args.until_year as u16);
     if args.apply {
         app = app.apply_changes();

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -42,7 +42,8 @@ fn test_app() {
         api_key: String::from("12"),
         host: format!("http://{}/api", addr).parse().unwrap(),
     };
-    let app = App::new(client.clone());
+
+    let app = App::new(client.clone(), 2000, 2026);
 
     let _handle = immich.spawn();
     app.run().unwrap();
@@ -50,7 +51,7 @@ fn test_app() {
     let asset = get_asset_by_id("1", &client).unwrap();
     assert_eq!(asset.exif_info, None);
 
-    let app = App::new(client.clone()).apply_changes();
+    let app = App::new(client.clone(), 2000, 2026).apply_changes();
     app.run().unwrap();
     let asset = get_asset_by_id("1", &client).unwrap();
     assert_eq!(


### PR DESCRIPTION
This commit adds the CLI options `--from-year` and `--until-year`.