### PR TITLE
GH-10 Ignore assets that already have an original date time

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -98,18 +98,9 @@ impl App {
                 let asset = get_asset_by_id(&asset.id, &self.client)?;
 
                 if let Some(exif_info) = asset.exif_info
-                    && let Some(original_date_time) = exif_info.date_time_original
+                    && let Some(_) = exif_info.date_time_original
                 {
-                    let original_date_time = original_date_time.parse::<DateTime>().ok();
-                    if let Some(original_date_time) = &original_date_time {
-                        if (*original_date_time - datetime).get_days() <= 1 {
-                            continue;
-                        };
-                        debug(format!(
-                            "Date of {} will be updated from {:?} to {:?}",
-                            asset.original_file_name, original_date_time, datetime,
-                        ));
-                    }
+                    continue;
                 }
 
                 if self.apply {


### PR DESCRIPTION
As of now, `retrodate` only configure a original date time if an asset doesn't have such value, yet.

In a future ticket, I'll require users to explicitly instruct `retrodate` to change the original date time if an asset already has a value set for this property.