### PR TITLE
GH-17 fix: retrieving search results

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -178,18 +178,32 @@ pub struct Client {
 fn get_assets_by_filename(file_name: &str, client: &Client) -> Result<Vec<Asset>> {
     let url = format!("{}/search/metadata", client.host);
 
-    let body: Search = ureq::post(&url)
-        .header("x-api-key", &client.api_key)
-        .config()
-        .timeout_global(Some(client.timeout))
-        .build()
-        .send_json(HashMap::from([("originalFileName", file_name)]))
-        .map_err(|error| explain_ureq_error(error, &url))?
-        .body_mut()
-        .read_json()
-        .map_err(|error| explain_ureq_error(error, &url))?;
+    let mut assets: Vec<Asset> = Vec::new();
+    let mut page = String::from("1");
 
-    Ok(body.assets.items)
+    loop {
+        let mut body: Search = ureq::post(&url)
+            .header("x-api-key", &client.api_key)
+            .config()
+            .timeout_global(Some(client.timeout))
+            .build()
+            .send_json(HashMap::from([
+                ("originalFileName", file_name),
+                ("page", &page),
+            ]))
+            .map_err(|error| explain_ureq_error(error, &url))?
+            .body_mut()
+            .read_json()
+            .map_err(|error| explain_ureq_error(error, &url))?;
+
+        assets.append(&mut body.assets.items);
+        let Some(next_page) = body.assets.next_page else {
+            break;
+        };
+        page = next_page;
+    }
+
+    Ok(assets)
 }
 
 pub fn get_asset_by_id(id: &str, client: &Client) -> Result<Asset> {
@@ -361,6 +375,11 @@ pub struct Search {
 pub struct Results {
     #[serde(alias = "assets")]
     pub items: Vec<Asset>,
+
+    pub next_page: Option<String>,
+
+    /// The total number of assets that match the query.
+    pub total: usize,
 }
 
 #[derive(Deserialize, Serialize, Debug, Clone)]
@@ -380,6 +399,7 @@ pub struct ExifInfo {
 #[serde(rename_all = "camelCase")]
 pub struct Query {
     pub original_file_name: String,
+    pub page: Option<String>,
 }
 
 #[derive(Deserialize, Serialize, Debug)]

--- a/tests/env/immich.rs
+++ b/tests/env/immich.rs
@@ -91,7 +91,7 @@ fn post_search_metadata(request: &mut Request, state: &mut [Asset]) -> Option<Re
         return Some(Response::empty(400).boxed());
     };
 
-    let matches = state
+    let matches: Vec<Asset> = state
         .iter()
         .filter_map(|asset| {
             if asset.original_file_name.contains(&query.original_file_name) {
@@ -102,11 +102,49 @@ fn post_search_metadata(request: &mut Request, state: &mut [Asset]) -> Option<Re
         })
         .collect();
 
+    // The total number of matches.
+    let match_count = matches.len();
+    let page_size = 2;
+    let page: usize = query.page.unwrap_or(String::from("1")).parse().unwrap();
+    let next_page = {
+        if page * page_size < match_count {
+            Some(format!("{}", page + 1))
+        } else {
+            None
+        }
+    };
+
+    // The filtered matches for this page.
+    let matches = matches
+        .into_iter()
+        .enumerate()
+        .filter_map(|(index, asset)| {
+            let offset = (page - 1) * page_size;
+
+            // The pages are starting from 1, whereas
+            // the assets use  zero based indexing.
+
+            if (index) < offset {
+                return None;
+            }
+
+            if (index) >= ((offset + 1) * page_size) {
+                return None;
+            }
+            Some(asset)
+        })
+        .collect();
+
     let Ok(search_results) = serde_json::to_string_pretty(&Search {
-        assets: Results { items: matches },
+        assets: Results {
+            total: match_count,
+            items: matches,
+            next_page,
+        },
     }) else {
         return Some(Response::empty(500).boxed());
     };
+    dbg!(&search_results);
 
     Some(Response::from_string(search_results).boxed())
 }

--- a/tests/env/immich.rs
+++ b/tests/env/immich.rs
@@ -128,7 +128,7 @@ fn post_search_metadata(request: &mut Request, state: &mut [Asset]) -> Option<Re
                 return None;
             }
 
-            if (index) >= ((offset + 1) * page_size) {
+            if (index) >= (offset + page_size) {
                 return None;
             }
             Some(asset)
@@ -144,7 +144,6 @@ fn post_search_metadata(request: &mut Request, state: &mut [Asset]) -> Option<Re
     }) else {
         return Some(Response::empty(500).boxed());
     };
-    dbg!(&search_results);
 
     Some(Response::from_string(search_results).boxed())
 }

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -87,7 +87,7 @@ fn test_app() {
 
     let asset = get_asset_by_id("4", &client).unwrap();
     assert!(asset.exif_info.is_none());
-    let asset = get_asset_by_id("1", &client).unwrap();
+    let asset = get_asset_by_id("5", &client).unwrap();
     assert_eq!(
         asset.exif_info,
         Some(ExifInfo {

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -1,7 +1,10 @@
-use std::time::{Duration, Instant};
+use std::{
+    sync::atomic::Ordering,
+    time::{Duration, Instant},
+};
 
 use env::Immich;
-use retrodate::{App, Asset, Client, ExifInfo, get_asset_by_id};
+use retrodate::{App, Asset, Client, ExifInfo, VERBOSE, get_asset_by_id};
 use ureq::http::Uri;
 
 mod env;
@@ -37,12 +40,19 @@ fn test_app() {
             original_file_name: String::from("Screenshot_19980927_200215.jpg"),
             exif_info: None,
         },
+        // Asset contains a date but not a time.
+        Asset {
+            id: String::from("5"),
+            original_file_name: String::from("Screenshot_2023-09-27T191315.jpg"),
+            exif_info: None,
+        },
     ];
 
     let immich = Immich::with_assets(assets);
     let addr = immich.listening_address();
     let host: Uri = format!("http://{}/api", addr).parse().unwrap();
 
+    VERBOSE.store(true, Ordering::Relaxed);
     let app = App::builder(host.clone(), String::from("api-key")).build();
 
     let _handle = immich.spawn();
@@ -77,6 +87,13 @@ fn test_app() {
 
     let asset = get_asset_by_id("4", &client).unwrap();
     assert!(asset.exif_info.is_none());
+    let asset = get_asset_by_id("1", &client).unwrap();
+    assert_eq!(
+        asset.exif_info,
+        Some(ExifInfo {
+            date_time_original: Some(String::from("2023-09-27T19:13:15"))
+        })
+    );
 }
 
 // Verify configuration the HTTP timeout works correctly.


### PR DESCRIPTION
`retrodate` uses the API endpoint /asset/metadata
to query assets. The results are paginated, at 250 results per page.

If more assets match the query, the results are
spread over multiple pages.

`retrodate`, however, only requests the first page. It didn't request the remaining pages.

This commit fixes that.