### PR TITLE
GH-15 feat!: Add flags --overwrite and --threshold. 

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Alternatively, use `--overwrite` to modify assets that already have a creation d
 ./retrodate --api-key "${API_KEY}" --host "${IMMICH_API}" --overwrite
 Date of Screenshot_20230927_191315.jpg set to 2023-09-27T19:13:15.
 Date of Screenshot_20231001.jpg set to 2023-10-01T00:00:00.
-Date of Screenshot_2023-11-02T041328.jpg set from 1970-01-01T00:00:00 to 2023-11-02T04:13:28.
+Change date of Screenshot_2023-11-02T041328.jpg from 1970-01-01T00:00:00 to 2023-11-02T04:13:28.
 ```
 
 Only touch assets that have 2017, 2018, or 2019 in their file name:

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Date of Screenshot_20231001.jpg will be set to 2023-10-01T00:00:00. Call `retrod
 Date of Screenshot_2023-11-02T041328.jpg will be changed from 1970-01-01T00:00:00 to 2023-11-02T04:13:28. Call `retrodate` with --overwrite to apply the change.
 ```
 
-Run the same command with the flag `--apply` added to apply the changes:
+Run the same command with the flag `--if-unset` added to apply the changes:
 
 ```bash
 ./retrodate --api-key "${API_KEY}" --host "${IMMICH_API}" --if-unset
@@ -40,6 +40,8 @@ Date of Screenshot_20230927_191315.jpg set to 2023-09-27T19:13:15.
 Date of Screenshot_20231001.jpg set to 2023-10-01T00:00:00.
 Skipping of Screenshot_2023-11-02T041328.jpg, the asset has datetime set to 1970-01-01T00:00:00. Call `retrodate` with --overwrite to replace the existing datetime.
 ```
+
+Alternatively, use `--overwrite` to modify assets that already have a creation date.
 
 ```bash
 ./retrodate --api-key "${API_KEY}" --host "${IMMICH_API}" --overwrite

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ It's either the screenshot was taken or the moment the media was shared.
 This tool extracts the date (and time, if included) from the filename and uses the Immich API to correct
 a pictures exif data.
 
-## Usage
+## Examples
 
 Obtain `retrodate` from the [releases](https://github.com/OrangeTux/retrodate/releases).
 
@@ -27,28 +27,61 @@ Then, run `retrodate` like this to list all changes `retrodate` likes to make:
 
 ```bash
 ./retrodate --api-key "${API_KEY}" --host "${IMMICH_API}" 
-Date of IMG_20180301_131212.jpg will be set to 2018-03-01T13:12:12. Run script with --apply to apply the change.
-Date of 20190720_130508.jpg will be set to 2019-07-20T13:05:08. Run script with --apply to apply the change.
-Date of Screenshot_20201225-162340_Nike Run Club.jpg will be set to 2020-12-25T16:23:40. Run script with --apply to apply the change.
-Date of Screenshot_20201202-183706_Spotify.jpg will be set to 2020-12-02T18:37:06. Run script with --apply to apply the change.
+Date of Screenshot_20230927_191315.jpg will be set to 2023-09-27T19:13:15. Call `retrodate` with --if-unset to apply the change.
+Date of Screenshot_20231001.jpg will be set to 2023-10-01T00:00:00. Call `retrodate` with --if-unset to apply the change.
+Date of Screenshot_2023-11-02T041328.jpg will be changed from 1970-01-01T00:00:00 to 2023-11-02T04:13:28. Call `retrodate` with --overwrite to apply the change.
 ```
 
 Run the same command with the flag `--apply` added to apply the changes:
 
 ```bash
-./retrodate --api-key "${API_KEY}" --host "${IMMICH_API}" --apply
-Date of IMG_20180301_131212.jpg set to 2018-03-01T13:12:12.
-Date of 20190720_130508.jpg set to 2019-07-20T13:05:08.
-Date of Screenshot_20201225-162340_Nike Run Club.jpg set to 2020-12-25T16:23:40.
-Date of Screenshot_20201202-183706_Spotify.jpg set to 2020-12-02T18:37:06. 
+./retrodate --api-key "${API_KEY}" --host "${IMMICH_API}" --if-unset
+Date of Screenshot_20230927_191315.jpg set to 2023-09-27T19:13:15.
+Date of Screenshot_20231001.jpg set to 2023-10-01T00:00:00.
+Skipping of Screenshot_2023-11-02T041328.jpg, the asset has datetime set to 1970-01-01T00:00:00. Call `retrodate` with --overwrite to replace the existing datetime.
+```
+
+```bash
+./retrodate --api-key "${API_KEY}" --host "${IMMICH_API}" --overwrite
+Date of Screenshot_20230927_191315.jpg set to 2023-09-27T19:13:15.
+Date of Screenshot_20231001.jpg set to 2023-10-01T00:00:00.
+Date of Screenshot_2023-11-02T041328.jpg set from 1970-01-01T00:00:00 to 2023-11-02T04:13:28.
 ```
 
 Only touch assets that have 2017, 2018, or 2019 in their file name:
 
 ```bash
-./retrodate --api-key "${API_KEY}" --host "${IMMICH_API}" --apply --from-year 2017 --until-year 2019
+./retrodate --api-key "${API_KEY}" --host "${IMMICH_API}" --if-unset --from-year 2017 --until-year 2019
 Date of IMG_20180301_131212.jpg set to 2018-03-01T13:12:12.
 Date of 20190720_130508.jpg set to 2019-07-20T13:05:08.
+```
+
+# Usage
+
+```bash
+$ ./retrodate --help
+Usage: retrodate --api-key <api-key> --host <host> [--if-unset] [--overwrite] [--threshold <threshold>] [-v] [--from-year <from-year>] [--until-year <until-year>] [--timeout <timeout>]
+
+Retrodate is a utility to retroactively date images on Immich based on an image's filename. This tool queries Immich for all filenames that contain a year, e.g. 2021 in 20210901_115950.jpg. Then, the date (and optional time) is parsed from the filename. You can control search using the arguments --from-year and --until-year.
+
+Options:
+  --api-key         API key providing access to Immich's API. It requires
+                    permissions 'asset.read' and 'asset.update'.
+  --host            URL of the immich API
+  --if-unset        set the creation date of an asset, only if that asset
+                    doesn't have a creation date already.
+  --overwrite       set the creation date of an asset, even if that asset has a
+                    creation date already. It sets --if-unset.
+  --threshold       maximum allowed time difference when deciding to update an
+                    asset's creation date. Provide a `jiff::Span` string such as
+                    `30m`, `1h`, `2d`, or `1h30m`.
+  -v, --verbose     explain what is being done
+  --from-year       the earliest year to include in the search, defaults to 2000
+  --until-year      the latest year to include in the search, defaults to the
+                    current year
+  --timeout         the maximum time in seconds for a single HTTP request
+                    against Immich's HTTP API
+  --help, help      display usage information
 ```
 
 ## License

--- a/README.md
+++ b/README.md
@@ -35,16 +35,16 @@ Date of Screenshot_2023-11-02T041328.jpg will be changed from 1970-01-01T00:00:0
 Run the same command with the flag `--if-unset` added to apply the changes:
 
 ```bash
-./retrodate --api-key "${API_KEY}" --host "${IMMICH_API}" --if-unset
+./retrodate --api-key "${API_KEY}" --host "${IMMICH_API}" --if-unset -v
 Date of Screenshot_20230927_191315.jpg set to 2023-09-27T19:13:15.
 Date of Screenshot_20231001.jpg set to 2023-10-01T00:00:00.
-Skipping of Screenshot_2023-11-02T041328.jpg, the asset has datetime set to 1970-01-01T00:00:00. Call `retrodate` with --overwrite to replace the existing datetime.
+Skipping Screenshot_2023-11-02T041328.jpg, the asset has datetime set to 1970-01-01T00:00:00. Call `retrodate` with --overwrite to replace the existing datetime.
 ```
 
 Alternatively, use `--overwrite` to modify assets that already have a creation date.
 
 ```bash
-./retrodate --api-key "${API_KEY}" --host "${IMMICH_API}" --overwrite
+./retrodate --api-key "${API_KEY}" --host "${IMMICH_API}" --overwrite -v
 Date of Screenshot_20230927_191315.jpg set to 2023-09-27T19:13:15.
 Date of Screenshot_20231001.jpg set to 2023-10-01T00:00:00.
 Change date of Screenshot_2023-11-02T041328.jpg from 1970-01-01T00:00:00 to 2023-11-02T04:13:28.
@@ -53,7 +53,7 @@ Change date of Screenshot_2023-11-02T041328.jpg from 1970-01-01T00:00:00 to 2023
 Only touch assets that have 2017, 2018, or 2019 in their file name:
 
 ```bash
-./retrodate --api-key "${API_KEY}" --host "${IMMICH_API}" --if-unset --from-year 2017 --until-year 2019
+./retrodate --api-key "${API_KEY}" --host "${IMMICH_API}" --if-unset --from-year 2017 --until-year 2019 -v
 Date of IMG_20180301_131212.jpg set to 2018-03-01T13:12:12.
 Date of 20190720_130508.jpg set to 2019-07-20T13:05:08.
 ```

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -144,24 +144,47 @@ impl App {
                 let maybe_date_time_original = asset
                     .exif_info
                     .and_then(|exif_info| {
-                        exif_info
-                            .date_time_original
-                            .map(|datetime| datetime.parse::<DateTime>().ok())
+                        exif_info.date_time_original.map(|datetime| {
+                            datetime
+                                .parse::<DateTime>()
+                                .inspect_err(|err| {
+                                    eprintln!(
+                                        "Failed to extract the datetime from {}: {err:?}",
+                                        asset.original_file_name
+                                    )
+                                })
+                                .ok()
+                        })
                     })
                     .flatten();
 
                 match (self.mode, maybe_date_time_original) {
-                    (Mode::DryRun, _) => {
+                    (Mode::DryRun, None) => {
                         println!(
-                            "Date of {} will be set to {:?}. Run script with --apply to apply the change.",
+                            "Date of {} will be set to {}. Call `retrodate` with --apply to apply the change.",
                             asset.original_file_name, datetime,
                         );
                     }
-                    (Mode::IfUnset, Some(_)) => {
+                    (Mode::DryRun, Some(date_time_original)) => {
+                        println!(
+                            "Date of {} will be changed from {} to {}. Call `retrodate` with --overwrite to apply the change.",
+                            asset.original_file_name, date_time_original, datetime,
+                        );
+                    }
+                    (Mode::IfUnset, Some(date_time_original)) => {
+                        debug(format!(
+                            "Skipping {}, the asset has datetime set {}. Call `retrodate` with --overwrite to replace the existing datetime.",
+                            asset.original_file_name, date_time_original
+                        ));
+
                         continue;
                     }
                     (Mode::IfUnset | Mode::OverWrite(_), None) => {
                         let _ = set_assets_date_time(&asset.id, &datetime, &self.client)?;
+                        debug(format!(
+                            "Date of {} set to {}.",
+                            asset.original_file_name, datetime
+                        ));
                     }
                     (Mode::OverWrite(interval), Some(date_time_original)) => {
                         if (datetime - date_time_original)
@@ -171,7 +194,15 @@ impl App {
                             == core::cmp::Ordering::Greater
                         {
                             let _ = set_assets_date_time(&asset.id, &datetime, &self.client)?;
+                            debug(format!(
+                                "Change date of {} from {} to {}.",
+                                asset.original_file_name, date_time_original, datetime
+                            ));
                         } else {
+                            debug(format!(
+                                "Skipping {}, the time difference between then existing datetime ({}) and the datetime extracted from the filename ({}) doesn't surpass the threshold of {:?}",
+                                asset.original_file_name, date_time_original, datetime, interval
+                            ));
                             continue;
                         }
                     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,6 @@
 use color_eyre::eyre::{Report, Result};
 use jiff::{
-    Zoned,
+    Span, Zoned,
     civil::{Date, DateTime, Time},
 };
 use regex::Regex;
@@ -56,6 +56,7 @@ static TIME_RE: LazyLock<Vec<Regex>> = LazyLock::new(|| {
             .expect("This shouldn't panic at runtime."),
     ]
 });
+
 /// Retrodate is a utility to retroactively date images on Immich based on an image's filename.
 ///
 /// This tool queries Immich for all filenames that contain a year, e.g. 2021 in 20210901_115950.jpg.
@@ -72,9 +73,17 @@ pub struct Args {
     #[argh(option)]
     pub host: String,
 
-    /// set the creation date of an asset.
+    /// set the creation date of an asset, only if that asset doesn't have a creation date already.
     #[argh(switch)]
-    pub apply: bool,
+    pub if_unset: bool,
+
+    /// set the creation date of an asset, even if that asset has a creation date already. It sets --if-unset.
+    #[argh(switch)]
+    pub overwrite: bool,
+
+    /// todo
+    #[argh(option)]
+    pub threshold: Option<String>,
 
     /// explain what is being done
     #[argh(switch, short = 'v')]
@@ -95,7 +104,7 @@ pub struct Args {
 
 pub struct App {
     client: Client,
-    apply: bool,
+    mode: Mode,
 
     year_range: RangeInclusive<u16>,
 }
@@ -132,20 +141,40 @@ impl App {
 
                 let asset = get_asset_by_id(&asset.id, &self.client)?;
 
-                if let Some(exif_info) = asset.exif_info
-                    && let Some(_) = exif_info.date_time_original
-                {
-                    continue;
-                }
+                let maybe_date_time_original = asset
+                    .exif_info
+                    .and_then(|exif_info| {
+                        exif_info
+                            .date_time_original
+                            .map(|datetime| datetime.parse::<DateTime>().ok())
+                    })
+                    .flatten();
 
-                if self.apply {
-                    let _ = set_assets_date_time(&asset.id, &datetime, &self.client)?;
-                    println!("Date of {} set to {:?}", asset.original_file_name, datetime,);
-                } else {
-                    println!(
-                        "Date of {} will be set to {:?}. Run script with --apply to apply the change.",
-                        asset.original_file_name, datetime,
-                    );
+                match (self.mode, maybe_date_time_original) {
+                    (Mode::DryRun, _) => {
+                        println!(
+                            "Date of {} will be set to {:?}. Run script with --apply to apply the change.",
+                            asset.original_file_name, datetime,
+                        );
+                    }
+                    (Mode::IfUnset, Some(_)) => {
+                        continue;
+                    }
+                    (Mode::IfUnset | Mode::OverWrite(_), None) => {
+                        let _ = set_assets_date_time(&asset.id, &datetime, &self.client)?;
+                    }
+                    (Mode::OverWrite(interval), Some(date_time_original)) => {
+                        if (datetime - date_time_original)
+                            .abs()
+                            .compare((interval, date_time_original))
+                            .unwrap()
+                            == core::cmp::Ordering::Greater
+                        {
+                            let _ = set_assets_date_time(&asset.id, &datetime, &self.client)?;
+                        } else {
+                            continue;
+                        }
+                    }
                 }
             }
         }
@@ -153,11 +182,26 @@ impl App {
     }
 }
 
+#[derive(Debug, Default, Copy, Clone)]
+pub enum Mode {
+    // Do not mutate assets.
+    #[default]
+    DryRun,
+
+    // Only mutate update assets that are lacking a dateTimeOriginal
+    IfUnset,
+
+    // Mutate all assets, both with and without dateTimeOriginal.
+    OverWrite(Span),
+}
+
+#[derive(Debug)]
 pub struct Builder {
     client: Client,
     from_year: u16,
     until_year: u16,
-    apply: bool,
+
+    mode: Mode,
 }
 
 impl Builder {
@@ -170,12 +214,22 @@ impl Builder {
             },
             from_year: 2000,
             until_year: current_year(),
-            apply: false,
+            mode: Mode::DryRun,
         }
     }
 
-    pub fn apply(mut self) -> Self {
-        self.apply = true;
+    pub fn dry_run(mut self) -> Self {
+        self.mode = Mode::DryRun;
+        self
+    }
+
+    pub fn if_unset(mut self) -> Self {
+        self.mode = Mode::IfUnset;
+        self
+    }
+
+    pub fn overwrite(mut self, interval: Span) -> Self {
+        self.mode = Mode::OverWrite(interval);
         self
     }
 
@@ -197,8 +251,8 @@ impl Builder {
     pub fn build(self) -> App {
         App {
             client: self.client,
+            mode: self.mode,
             year_range: self.from_year..=self.until_year,
-            apply: self.apply,
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -81,7 +81,8 @@ pub struct Args {
     #[argh(switch)]
     pub overwrite: bool,
 
-    /// todo
+    /// maximum allowed time difference when deciding to update an asset's creation date.
+    /// Provide a `jiff::Span` string such as `30m`, `1h`, `2d`, or `1h30m`.
     #[argh(option)]
     pub threshold: Option<String>,
 
@@ -161,7 +162,7 @@ impl App {
                 match (self.mode, maybe_date_time_original) {
                     (Mode::DryRun, None) => {
                         println!(
-                            "Date of {} will be set to {}. Call `retrodate` with --apply to apply the change.",
+                            "Date of {} will be set to {}. Call `retrodate` with --if-unset to apply the change.",
                             asset.original_file_name, datetime,
                         );
                     }
@@ -179,14 +180,14 @@ impl App {
 
                         continue;
                     }
-                    (Mode::IfUnset | Mode::OverWrite(_), None) => {
+                    (Mode::IfUnset | Mode::Overwrite(_), None) => {
                         let _ = set_assets_date_time(&asset.id, &datetime, &self.client)?;
                         debug(format!(
                             "Date of {} set to {}.",
                             asset.original_file_name, datetime
                         ));
                     }
-                    (Mode::OverWrite(interval), Some(date_time_original)) => {
+                    (Mode::Overwrite(interval), Some(date_time_original)) => {
                         if (datetime - date_time_original)
                             .abs()
                             .compare((interval, date_time_original))
@@ -200,7 +201,7 @@ impl App {
                             ));
                         } else {
                             debug(format!(
-                                "Skipping {}, the time difference between then existing datetime ({}) and the datetime extracted from the filename ({}) doesn't surpass the threshold of {:?}",
+                                "Skipping {}, the time difference between the existing datetime ({}) and the datetime extracted from the filename ({}) doesn't surpass the threshold of {:?}",
                                 asset.original_file_name, date_time_original, datetime, interval
                             ));
                             continue;
@@ -219,11 +220,11 @@ pub enum Mode {
     #[default]
     DryRun,
 
-    // Only mutate update assets that are lacking a dateTimeOriginal
+    // Only mutate assets that are lacking a creation date.
     IfUnset,
 
-    // Mutate all assets, both with and without dateTimeOriginal.
-    OverWrite(Span),
+    // Mutate all assets, both with and without creation date.
+    Overwrite(Span),
 }
 
 #[derive(Debug)]
@@ -260,7 +261,7 @@ impl Builder {
     }
 
     pub fn overwrite(mut self, interval: Span) -> Self {
-        self.mode = Mode::OverWrite(interval);
+        self.mode = Mode::Overwrite(interval);
         self
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -30,7 +30,9 @@ fn main() -> Result<()> {
         .threshold
         .map(|value| value.parse::<Span>())
         .transpose()
-        .unwrap();
+        .wrap_err_with(|| {
+            "failed to parse the value of --threshold, use a value like '1d' or '24h'".to_string()
+        })?;
 
     let builder = match (args.overwrite, threshold) {
         (false, _) => builder,

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,5 @@
 use color_eyre::eyre::{Result, WrapErr};
+use jiff::Span;
 use retrodate::{App, Args, VERBOSE};
 use std::{sync::atomic::Ordering, time::Duration};
 
@@ -21,9 +22,21 @@ fn main() -> Result<()> {
         .until_year(args.until_year)
         .http_timeout(Duration::from_secs(args.timeout));
 
-    if args.apply {
-        builder = builder.apply();
+    if args.if_unset {
+        builder = builder.if_unset();
     }
+
+    let threshold = args
+        .threshold
+        .map(|value| value.parse::<Span>())
+        .transpose()
+        .unwrap();
+
+    let builder = match (args.overwrite, threshold) {
+        (false, _) => builder,
+        (true, None) => builder.overwrite(Span::new()),
+        (true, Some(interval)) => builder.overwrite(interval),
+    };
 
     let app = builder.build();
     app.run()

--- a/tests/env/immich.rs
+++ b/tests/env/immich.rs
@@ -39,7 +39,7 @@ impl Immich {
     pub fn handle_single_request(&mut self) {
         let mut request = self.server.recv().unwrap();
 
-        println!("Received {} {}", request.method(), request.url());
+        // println!("Received {} {}", request.method(), request.url());
 
         if request
             .headers()

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -10,12 +10,8 @@ use ureq::http::Uri;
 
 mod env;
 
-/// Test the business logic against an Immich fake.
-/// First, this test creates an App instance and verifies that the date of the asset is _not_ set.
-/// Then, an App instance is created with "apply_changes()" and the test verifies that the date of the asset _is_ set.
-#[test]
-fn test_app() {
-    let assets = vec![
+fn default_assets() -> Vec<Asset> {
+    vec![
         // Asset contains a valid date and time.
         Asset {
             id: String::from("1"),
@@ -47,9 +43,30 @@ fn test_app() {
             original_file_name: String::from("Screenshot_2023-09-27T191315.jpg"),
             exif_info: None,
         },
-    ];
-
-    let immich = Immich::with_assets(assets);
+        // Asset contains valid date and time. But it already a value for dateTimeOriginal.
+        Asset {
+            id: String::from("6"),
+            original_file_name: String::from("Screenshot_2023-09-27T191315.jpg"),
+            exif_info: Some(ExifInfo {
+                date_time_original: Some(String::from("1970-01-01T00:00:00")),
+            }),
+        },
+        // Asset contains valid date and time. But it already a value for dateTimeOriginal.
+        Asset {
+            id: String::from("7"),
+            original_file_name: String::from("Screenshot_2023-09-27T191315.jpg"),
+            exif_info: Some(ExifInfo {
+                date_time_original: Some(String::from("2023-09-27T20:00:00")),
+            }),
+        },
+    ]
+}
+/// Test the business logic against an Immich fake.
+/// First, this test creates an App instance and verifies that the date of the asset is _not_ set.
+/// Then, an App instance is created with "if_unset()" and the test verifies that the date of the asset _is_ set.
+#[test]
+fn test_app_created_with_if_unset() {
+    let immich = Immich::with_assets(default_assets());
     let addr = immich.listening_address();
     let host: Uri = format!("http://{}/api", addr).parse().unwrap();
 
@@ -68,7 +85,7 @@ fn test_app() {
     assert_eq!(asset.exif_info, None);
 
     let app = App::builder(host, String::from("api-key"))
-        .overwrite(Span::new())
+        .if_unset()
         .build();
 
     app.run().unwrap();
@@ -98,8 +115,56 @@ fn test_app() {
             date_time_original: Some(String::from("2023-09-27T19:13:15"))
         })
     );
+    let asset = get_asset_by_id("6", &client).unwrap();
+    assert_eq!(
+        asset.exif_info,
+        Some(ExifInfo {
+            date_time_original: Some(String::from("1970-01-01T00:00:00"))
+        })
+    );
 }
 
+#[test]
+fn test_app_created_with_overwrite() {
+    let immich = Immich::with_assets(default_assets());
+    let addr = immich.listening_address();
+    let host: Uri = format!("http://{}/api", addr).parse().unwrap();
+
+    VERBOSE.store(true, Ordering::Relaxed);
+    let app = App::builder(host.clone(), String::from("api-key"))
+        .overwrite(Span::new().days(1))
+        .build();
+
+    let _handle = immich.spawn();
+    app.run().unwrap();
+
+    let client = Client {
+        host: host.clone(),
+        api_key: String::from("api-key"),
+        timeout: Duration::from_secs(1),
+    };
+    let asset = get_asset_by_id("1", &client).unwrap();
+    assert_eq!(
+        asset.exif_info,
+        Some(ExifInfo {
+            date_time_original: Some(String::from("2023-09-27T19:13:15"))
+        })
+    );
+    let asset = get_asset_by_id("6", &client).unwrap();
+    assert_eq!(
+        asset.exif_info,
+        Some(ExifInfo {
+            date_time_original: Some(String::from("2023-09-27T19:13:15"))
+        })
+    );
+    let asset = get_asset_by_id("7", &client).unwrap();
+    assert_eq!(
+        asset.exif_info,
+        Some(ExifInfo {
+            date_time_original: Some(String::from("2023-09-27T20:00:00"))
+        })
+    );
+}
 // Verify configuration the HTTP timeout works correctly.
 #[test]
 fn verify_http_timeout() {

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -4,6 +4,7 @@ use std::{
 };
 
 use env::Immich;
+use jiff::Span;
 use retrodate::{App, Asset, Client, ExifInfo, VERBOSE, get_asset_by_id};
 use ureq::http::Uri;
 
@@ -66,7 +67,10 @@ fn test_app() {
     let asset = get_asset_by_id("1", &client).unwrap();
     assert_eq!(asset.exif_info, None);
 
-    let app = App::builder(host, String::from("api-key")).apply().build();
+    let app = App::builder(host, String::from("api-key"))
+        .overwrite(Span::new())
+        .build();
+
     app.run().unwrap();
     let asset = get_asset_by_id("1", &client).unwrap();
     assert_eq!(


### PR DESCRIPTION
If `--overwrite` is set, `retrodate` will always
set an asset's originalDateTime value, even if it
already had a value for originalDateTime.

If `--threshold` is set, one can configure the minimum
interval between the old and the new originalDateTime.
E.g. a value of "1d" means that the asset is updated
only, if the old and the new originalDateTime are
more than 1 day apart.

This commit renames the option  `--apply` with `--if-unset`,
making this commit backwards incompatible.