### PR TITLE
GH-23 Use `git cliff` to generate CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,49 @@
+## [unreleased]
+
+### Features
+
+- [**breaking**] Add flags --overwrite and --threshold.  ([#22](https://github.com/orangetux/retrodate/issues/22))
+
+### Other
+
+- X
+## [0.2.2] - 2026-05-06
+
+### Features
+
+- Support more formats, among others DD-MM-YYYY ([#20](https://github.com/orangetux/retrodate/issues/20))
+## [0.2.1] - 2026-05-05
+
+### Bug Fixes
+
+- Retrieving search results ([#18](https://github.com/orangetux/retrodate/issues/18))
+
+### Other
+
+- Add note about the current limitations ([#12](https://github.com/orangetux/retrodate/issues/12))
+## [0.2.0] - 2026-05-04
+
+### Other
+
+- Allow users to configure years to include in search ([#6](https://github.com/orangetux/retrodate/issues/6))
+- Allow users to set timeout for HTTP requests ([#7](https://github.com/orangetux/retrodate/issues/7))
+- Extract datetime from wider range of formats ([#9](https://github.com/orangetux/retrodate/issues/9))
+- Ignore assets that already have an original date time ([#11](https://github.com/orangetux/retrodate/issues/11))
+## [0.1.1] - 2026-05-01
+
+### Other
+
+- Remove release for aarch64-pc-windows-mvc
+## [0.1.0] - 2026-05-01
+
+### Other
+
+- Initial commit
+- Replace `unwrap()` with proper error reporting
+- Colorize fatal errors
+- Add -v switch to increase verbosity
+- Add validation of host option
+- Add integration test ([#1](https://github.com/orangetux/retrodate/issues/1))
+- Rebrand to retrodate and add MIT License ([#4](https://github.com/orangetux/retrodate/issues/4))
+- Lint, test and release retrodate in CI ([#5](https://github.com/orangetux/retrodate/issues/5))
+- Add usage instructions

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,8 @@
 
 ### Other
 
-- X
+- Use `git cliff` to generate CHANGELOG.md
+
 ## [0.2.2] - 2026-05-06
 
 ### Features

--- a/README.md
+++ b/README.md
@@ -86,6 +86,14 @@ Options:
   --help, help      display usage information
 ```
 
+## Contributing
+
+After mutating some code, run `scripts/lint.sh` and `scripts/test.sh` to verify
+correctness.
+
+The release manager should run `scripts/prepare-release.sh` before releasing a
+new version. This script updates the `CHANGELOG.md` and the version number in `Cargo.toml`.
+
 ## License
 
 This project is published under the [MIT license](LICENSE).

--- a/cliff.toml
+++ b/cliff.toml
@@ -87,7 +87,7 @@ filter_commits = false
 fail_on_unmatched_commit = false
 # An array of link parsers for extracting external references, and turning them into URLs, using regex.
 link_parsers = [
-    { pattern = "#(\\d+)", href = "https://github.com/auke/retrodate/issues/$1"},
+    { pattern = "#(\\d+)", href = "https://github.com/orangetux/retrodate/issues/$1"},
 ]
 # Include only the tags that belong to the current branch.
 use_branch_tags = false

--- a/cliff.toml
+++ b/cliff.toml
@@ -1,0 +1,110 @@
+# git-cliff ~ configuration file
+# https://git-cliff.org/docs/configuration
+
+
+[changelog]
+# A Tera template to be rendered for each release in the changelog.
+# See https://keats.github.io/tera/docs/#introduction
+body = """
+{% if version %}\
+    ## [{{ version | trim_start_matches(pat="v") }}] - {{ timestamp | date(format="%Y-%m-%d") }}
+{% else %}\
+    ## [unreleased]
+{% endif %}\
+{% for group, commits in commits | group_by(attribute="group") %}
+    ### {{ group | striptags | trim | upper_first }}
+    {% for commit in commits %}
+        - {% if commit.scope %}*({{ commit.scope }})* {% endif %}\
+            {% if commit.breaking %}[**breaking**] {% endif %}\
+            {{ commit.message | upper_first }}\
+    {% endfor %}
+{% endfor %}
+"""
+# Remove leading and trailing whitespaces from the changelog's body.
+trim = true
+# Render body even when there are no releases to process.
+render_always = true
+# An array of regex based postprocessors to modify the changelog.
+postprocessors = [
+    # Replace issue links with actual GitHub URLs.
+    { pattern = '\(#([0-9]+)\)', replace = "([#${1}](https://github.com/orangetux/retrodate/issues/${1}))"},
+]
+# render body even when there are no releases to process
+# render_always = true
+# output file path
+# output = "test.md"
+
+[git]
+# Parse commits according to the conventional commits specification.
+# See https://www.conventionalcommits.org
+conventional_commits = true
+# Exclude commits that do not match the conventional commits specification.
+filter_unconventional = false
+# Require all commits to be conventional.
+# Takes precedence over filter_unconventional.
+require_conventional = false
+# Split commits on newlines, treating each line as an individual commit.
+split_commits = false
+# An array of regex based parsers to modify commit messages prior to further processing.
+commit_preprocessors = [
+    # Strip GH-X prefix for conventional commit parsing
+    # Capture only first line, strip commit body
+    { pattern = '(?s)GH-[0-9]+ (.+?)\n.*', replace = "${1}"},
+    # Fallback: strip GH-X prefix if there's no body
+    { pattern = 'GH-[0-9]+ (.+)', replace = "${1}"},
+    # Strip body from all commits (keep only first line)
+    { pattern = '(?s)(.+?)\n\n.*', replace = "${1}"},
+    # Check spelling of the commit message using https://github.com/crate-ci/typos.
+    # If the spelling is incorrect, it will be fixed automatically.
+    #{ pattern = '.*', replace_command = 'typos --write-changes -' },
+]
+# Prevent commits that are breaking from being excluded by commit parsers.
+protect_breaking_commits = false
+# An array of regex based parsers for extracting data from the commit message.
+# Assigns commits to groups.
+# Optionally sets the commit's scope and can decide to exclude commits from further processing.
+commit_parsers = [
+    { message = "^feat", group = "<!-- 0 --> Features" },
+    { message = "^fix", group = "<!-- 1 --> Bug Fixes" },
+    { message = "^doc", group = "<!-- 3 --> Documentation" },
+    { message = "^perf", group = "<!-- 4 --> Performance" },
+    { message = "^refactor", group = "<!-- 2 --> Refactor" },
+    { message = "^style", group = "<!-- 5 --> Styling" },
+    { message = "^test", group = "<!-- 6 --> Testing" },
+    { message = "^chore\\(release\\): prepare for", skip = true },
+    { message = "^chore\\(deps.*\\)", skip = true },
+    { message = "^chore\\(pr\\)", skip = true },
+    { message = "^chore\\(pull\\)", skip = true },
+    { message = "^Bump to", skip = true },
+    { message = "^chore|^ci", group = "<!-- 7 --> Miscellaneous Tasks" },
+    { body = ".*security", group = "<!-- 8 --> Security" },
+    { message = "^revert", group = "<!-- 9 --> Revert" },
+    { message = ".*", group = "<!-- 10 --> Other" },
+]
+# Exclude commits that are not matched by any commit parser.
+filter_commits = false
+# Fail on a commit that is not matched by any commit parser.
+fail_on_unmatched_commit = false
+# An array of link parsers for extracting external references, and turning them into URLs, using regex.
+link_parsers = [
+    { pattern = "#(\\d+)", href = "https://github.com/auke/retrodate/issues/$1"},
+]
+# Include only the tags that belong to the current branch.
+use_branch_tags = false
+# Order releases topologically instead of chronologically.
+topo_order = false
+# Order commits topologically instead of chronologically.
+topo_order_commits = true
+# Order of commits in each group/release within the changelog.
+# Allowed values: newest, oldest
+sort_commits = "oldest"
+# Process submodules commits
+recurse_submodules = false
+
+
+[bump]
+# If release is < 1.0.0, git cliff won't jump
+# to 1.0.0 on a breaking change. Instead, it increases
+# the minor digit. 
+features_always_bump_minor = false
+breaking_always_bump_major = false

--- a/scripts/prepare-release.sh
+++ b/scripts/prepare-release.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+set -e
+
+git cliff \
+  --unreleased \
+  --bump \
+  --prepend CHANGELOG.md
+
+version=$(git cliff --bumped-version)
+
+sed  -i 's/^version = ".*"/version = "'${version//[v]}'"/g' Cargo.toml
+cargo build

--- a/scripts/prepare-release.sh
+++ b/scripts/prepare-release.sh
@@ -1,5 +1,8 @@
 #!/usr/bin/env bash
-set -e
+set -euo pipefail
+
+# Ensure script works when invoked from anywhere in the repo:
+cd "$(dirname "$0")/.." || exit 1
 
 git cliff \
   --unreleased \
@@ -8,5 +11,5 @@ git cliff \
 
 version=$(git cliff --bumped-version)
 
-sed  -i 's/^version = ".*"/version = "'${version//[v]}'"/g' Cargo.toml
+sed  -i 's/^version = ".*"/version = "'${version#v}'"/g' Cargo.toml
 cargo build


### PR DESCRIPTION
Before releasing a new version, run `scripts/prepare-release.sh` to update the `CHANGELOG.md` with latest changes
and to increase the version number in `Cargo.toml`.